### PR TITLE
Add ability to select repo/branch to watch

### DIFF
--- a/git-notify
+++ b/git-notify
@@ -7,13 +7,13 @@ format_when="--format=%cr"
 format_summary="--format=%s"
 format_body="--format=%b"
 
-# what repository do we want to watch.
+# what repository do we want to watch (default to origin/master)
 if [ -z "$1" ]; then
 	repository="origin/master"
 else
 	repository="$1"
 fi
-	latest_revision="none"
+latest_revision="none"
 
 # loop forever, need to kill the process.
 while [ 1 ]; do
@@ -49,4 +49,4 @@ while [ 1 ]; do
 done
 }
 
-(run &)
+(run $1 &)

--- a/git-notify
+++ b/git-notify
@@ -8,8 +8,12 @@ format_summary="--format=%s"
 format_body="--format=%b"
 
 # what repository do we want to watch.
-repository="origin/master"
-latest_revision="none"
+if [ -z "$1" ]; then
+	repository="origin/master"
+else
+	repository="$1"
+fi
+	latest_revision="none"
 
 # loop forever, need to kill the process.
 while [ 1 ]; do
@@ -34,7 +38,6 @@ while [ 1 ]; do
         body="$commit_summary\n\n$commit_body"
 	if [ "`uname`" == "Darwin" ]
 	then
-		say -v Daniel "Commit made to $repository"
 		command="osascript -e 'display notification \"$body\" with title \"$summary\"'"
 		eval $command
 	else

--- a/git-notify
+++ b/git-notify
@@ -34,6 +34,7 @@ while [ 1 ]; do
         body="$commit_summary\n\n$commit_body"
 	if [ "`uname`" == "Darwin" ]
 	then
+		say -v Daniel "Commit made to $repository"
 		command="osascript -e 'display notification \"$body\" with title \"$summary\"'"
 		eval $command
 	else


### PR DESCRIPTION
Minor change to allow user to select a different repo/branch to watch. Defaults to origin/master, so using git-notify the old way will still work exactly the same way. 