### PR TITLE
Fail when not in a .git directory

### DIFF
--- a/git-notify
+++ b/git-notify
@@ -49,4 +49,8 @@ while [ 1 ]; do
 done
 }
 
-(run $1 &)
+if git rev-parse --git-dir > /dev/null 2>&1; then
+	(run $1 &)
+else
+	echo "Error: not a git repository"
+fi


### PR DESCRIPTION
Another small tweak. Script now fails if not in a git repo, so you don't have to go kill the process to stop the obnoxious error messages that'll keep popping up otherwise.